### PR TITLE
jsfiddle-to-git 1.1.1 Added badges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-15 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
+Copyright (c) 2014-16 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# jsfiddle-to-git [![Support this project][donate-now]][paypal-donations]
+# jsfiddle-to-git [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/jsfiddle-to-git.svg)](https://www.npmjs.com/package/jsfiddle-to-git) [![Downloads](https://img.shields.io/npm/dt/jsfiddle-to-git.svg)](https://www.npmjs.com/package/jsfiddle-to-git) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
-Convert a JSFiddle to Git repository.
+> Convert a JSFiddle to Git repository.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsfiddle-to-git",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Convert a JSFiddle to Git repository.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
 - Added badges :tada:
   - [PayPal Donations](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW)
   - npm downloads
   - npm version
   - Travis (if there are tests)
   - [CodeMentor](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)–you can ping me there if you need help with one of these modules (or help in general).
 - Updated the LICENSE year. :fireworks:
